### PR TITLE
Don't exit when a connection fails and adds Paddle.reconnect/1

### DIFF
--- a/lib/paddle.ex
+++ b/lib/paddle.ex
@@ -105,7 +105,7 @@ defmodule Paddle do
   alias Paddle.Filters
   alias Paddle.Attributes
 
-  @typep ldap_conn :: :eldap.handle
+  @typep ldap_conn :: :eldap.handle | {:not_connected, charlist}
   @type ldap_entry :: %{required(binary) => binary}
   @type auth_status :: :ok | {:error, atom}
 

--- a/lib/paddle.ex
+++ b/lib/paddle.ex
@@ -177,7 +177,7 @@ defmodule Paddle do
 
   @impl GenServer
   def handle_call(_message, _from, {:not_connected, _reason} = state) do
-    {:reply, {:error, state}, state}
+    {:reply, {:error, :not_connected}, state}
   end
 
   @impl GenServer

--- a/lib/paddle.ex
+++ b/lib/paddle.ex
@@ -105,7 +105,7 @@ defmodule Paddle do
   alias Paddle.Filters
   alias Paddle.Attributes
 
-  @typep ldap_conn :: :eldap.handle | {:not_connected, charlist}
+  @typep ldap_conn :: :eldap.handle | {:not_connected, binary}
   @type ldap_entry :: %{required(binary) => binary}
   @type auth_status :: :ok | {:error, atom}
 
@@ -299,7 +299,7 @@ defmodule Paddle do
   Example:
 
       iex> Paddle.reconnect(host: ['example.com'])
-      {:error, {:not_connected, 'connect failed'}}
+      {:error, {:not_connected, "connect failed"}}
       iex> Paddle.reconnect()
       {:ok, :connected}
   """
@@ -725,7 +725,7 @@ defmodule Paddle do
         {:ok, ldap_conn}
       {:error, reason} ->
         Logger.info("Failed to connect to LDAP")
-        {:error, reason}
+        {:error, Kernel.to_string(reason)}
     end
   end
 end

--- a/lib/paddle.ex
+++ b/lib/paddle.ex
@@ -180,6 +180,12 @@ defmodule Paddle do
   @spec terminate(reason, ldap_conn) :: :ok
 
   @impl GenServer
+  def terminate(_reason, :not_connected) do
+    :ok
+    Logger.info("Stopped LDAP, state was not connected")
+  end
+
+  @impl GenServer
   def terminate(_reason, ldap_conn) do
     :eldap.close(ldap_conn)
     Logger.info("Stopped LDAP")

--- a/lib/paddle.ex
+++ b/lib/paddle.ex
@@ -121,21 +121,21 @@ defmodule Paddle do
   @spec start_link(term) :: Genserver.on_start
 
   @doc false
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  @spec init(:ok) :: {:ok, ldap_conn}
+  @spec init([]) :: {:ok, ldap_conn}
 
   @impl GenServer
-  def init(:ok) do
-    ssl     = config(:ssl)
-    ipv6    = config(:ipv6)
-    tcpopts = config(:tcpopts)
-    sslopts = config(:sslopts)
-    host    = config(:host)
-    port    = config(:port)
-    timeout = config(:timeout)
+  def init(opts \\ []) do
+    ssl     = Keyword.get(opts, :ssl, config(:ssl))
+    ipv6    = Keyword.get(opts, :ipv6, config(:ipv6))
+    tcpopts = Keyword.get(opts, :tcpopts, config(:tcpopts))
+    sslopts = Keyword.get(opts, :sslopts, config(:sslopts))
+    host    = Keyword.get(opts, :host, config(:host))
+    port    = Keyword.get(opts, :port, config(:port))
+    timeout = Keyword.get(opts, :timeout, config(:timeout))
 
     Logger.info("Connecting to ldap#{if ssl, do: "s"}://#{inspect host}:#{port}")
 

--- a/test/paddle_test.exs
+++ b/test/paddle_test.exs
@@ -12,8 +12,8 @@ defmodule PaddleTest do
   test "when a connection cannot be open" do
     Paddle.reconnect(host: ['example.com'])
 
-    assert Paddle.authenticate([cn: "admin"], "password") == {:error, :not_connected}
-    assert Paddle.get(base: [uid: "testuser", ou: "People"]) == {:error, :not_connected}
+    assert Paddle.authenticate([cn: "admin"], "password") == {:error, {:not_connected, 'connect failed'}}
+    assert Paddle.get(base: [uid: "testuser", ou: "People"]) == {:error, {:not_connected, 'connect failed'}}
 
     Paddle.reconnect()
   end

--- a/test/paddle_test.exs
+++ b/test/paddle_test.exs
@@ -12,8 +12,8 @@ defmodule PaddleTest do
   test "when a connection cannot be open" do
     Paddle.reconnect(host: ['example.com'])
 
-    assert Paddle.authenticate([cn: "admin"], "password") == {:error, {:not_connected, 'connect failed'}}
-    assert Paddle.get(base: [uid: "testuser", ou: "People"]) == {:error, {:not_connected, 'connect failed'}}
+    assert Paddle.authenticate([cn: "admin"], "password") == {:error, :not_connected}
+    assert Paddle.get(base: [uid: "testuser", ou: "People"]) == {:error, :not_connected}
 
     Paddle.reconnect()
   end

--- a/test/paddle_test.exs
+++ b/test/paddle_test.exs
@@ -9,4 +9,12 @@ defmodule PaddleTest do
     assert Paddle.get!(%MyApp.Room{roomNumber: 42})    == [%MyApp.Room{cn: ["meetingRoom"], description: ["The Room where meetings happens"], roomNumber: ["42"]}]
   end
 
+  test "when a connection cannot be open" do
+    Paddle.reconnect(host: ['example.com'])
+
+    assert Paddle.authenticate([cn: "admin"], "password") == {:error, :not_connected}
+    assert Paddle.get(base: [uid: "testuser", ou: "People"]) == {:error, :not_connected}
+
+    Paddle.reconnect()
+  end
 end


### PR DESCRIPTION
This PR is a complement to #20.

It still needs improvements but the code works.

When starting Paddle, if the connection fails it will hold `:not_connected` as the state and will reply `{:error, :not_connected}` for messages it receives.

`Paddle.reconnect/1` was added, it will reconnect using the connection options received as argument or fetch the options from the config.