### PR TITLE
paddle.ex: fix get/1 and get!/1 specs

### DIFF
--- a/lib/paddle.ex
+++ b/lib/paddle.ex
@@ -390,6 +390,7 @@ defmodule Paddle do
                     :base})
   end
 
+  @spec get(Paddle.Class.t) :: {:ok, [Paddle.Class.t]} | {:error, search_ldap_error}
   @spec get(Paddle.Class.t, Paddle.Filters.t) :: {:ok, [Paddle.Class.t]} | {:error, search_ldap_error}
 
   @doc ~S"""
@@ -445,6 +446,7 @@ defmodule Paddle do
     result
   end
 
+  @spec get!(Paddle.Class.t) :: [Paddle.Class.t]
   @spec get!(Paddle.Class.t, Paddle.Filters.t) :: [Paddle.Class.t]
 
   @doc ~S"""


### PR DESCRIPTION
Add clauses accepting and returning Paddle.Class.t to avoid Dialyzer warnings

Dialyzer was giving me this warning:
```
ElixirLS Dialyzer: The function call will not succeed.

Paddle.get(%LDAP.User{
  :cn => nil,
  :displayName => nil,
  :dn => nil,
  :givenName => nil,
  :mail => _,
  :objectClass => nil,
  :sn => nil,
  :uid => nil,
  :userPassword => nil
})

breaks the contract
(dn()) :: {:ok, [ldap_entry()]} | {:error, search_ldap_error()}
```

Where `%LDAP.User{}` is a struct implementing the `Paddle.Class` protocol.

This PR fixes that warning.