### PR TITLE
add fix in Parsing to clean_eldap_search_results with :asn1_NOVALUE

### DIFF
--- a/lib/paddle/parsing.ex
+++ b/lib/paddle/parsing.ex
@@ -157,6 +157,10 @@ defmodule Paddle.Parsing do
     {:ok, clean_entries(entries, base)}
   end
 
+  def clean_eldap_search_results({:ok, {:eldap_search_result, entries, [], :asn1_NOVALUE}}, base) do
+    {:ok, clean_entries(entries, base)}
+  end
+
   @spec entry_to_class_object(Paddle.ldap_entry, Paddle.Class.t) :: Paddle.Class.t
 
   @doc ~S"""


### PR DESCRIPTION
I cant get entries when calling Paddle.get() with filter, filter and base, empty base(base: []).
Getting  `** (FunctionClauseError) no function clause matching in Paddle.Parsing.clean_eldap_search_results/2 (paddle 0.1.4) lib/paddle/parsing.ex:148: ...`
Using elixir 1.14.3-otp-25 erlang 25.2.1 