### PR TITLE
fix parsing when dn equals base

### DIFF
--- a/lib/paddle/parsing.ex
+++ b/lib/paddle/parsing.ex
@@ -228,7 +228,11 @@ defmodule Paddle.Parsing do
   defp strip_base_from_dn(dn, 0) when is_binary(dn), do: dn
   defp strip_base_from_dn(dn, base_length) when is_binary(dn) do
     dn_length = String.length(dn)
-    String.slice(dn, 0, dn_length - base_length - 1)
+    slice_length = case dn_length - base_length do
+      0 -> 0
+      _ -> dn_length - base_length - 1
+    end
+    String.slice(dn, 0, slice_length)
   end
 
   # ===================


### PR DESCRIPTION
fix bug when ending position for slice is -1
i have this problem
`[error] GenServer Paddle terminating
** (FunctionClauseError) no function clause matching in String.slice/3
    (elixir 1.14.3) lib/string.ex:2111: String.slice("dc=company,dc=loc", 0, -1)`

Elixir 1.14.3 Erlang 25.2.1